### PR TITLE
Let Pending PRs be created (PHNX-9093)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,4 @@ Renovate is a dependency update tool https://github.com/renovatebot/renovate
 ----
 
 - `rangeStrategy` is set to `bump` so minor/patch npm version updates would not be ignored
-- `prCreation: not-pending` is necessary for `stabilityDays` to work
 - `stabilityDays` is helpful to prevent upgrading to packages that have only been released very recently. Such as npm packages are allowed to be removed from the npm repo within a few day of initial release. If we update a third party npm package and then it's removed from npm entirely that would not be good.

--- a/default.json
+++ b/default.json
@@ -12,7 +12,6 @@
             "enabled": false      
         }         
     ],
-    "prCreation": "not-pending",
     "prBodyNotes": "@centeredge engineers  \r\n\r\n - If a package is responsible for a regression remove it from this auto generated PR then make a Jira ticket to only update that package \r\n - If any single packages aren't passing the [stabilityDays](https://docs.renovatebot.com/configuration-options/#stabilitydays) check then the entire PR containing other packages will not be made (ideally just that one package would be excluded, but this is a limitation of the current system). Search \"stability\" in the [Renovate logs](https://app.renovatebot.com/dashboard#github/CenterEdge/TempPackageManagerConcept) to find which package is being blocked",
     "schedule": ["every 1 hours every weekday"],
     "timezone": "America/New_York"


### PR DESCRIPTION
Motivation
---
`prCreation: pending` will never create a PR if a new renovate branch is failing tests, because the PR checks are still "pending", which means we'll probably never see the failing tests and never attempt to fix them

Modification
---
Let Pending PRs be created, hopefully that doesn't break stabilityDays

https://centeredge.atlassian.net/browse/PHNX-9093
