### PR TITLE
Don't ignore any paths (PHNX-9098)

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,10 +1,10 @@
 {
-    "extends": [
-      "config:base"
-    ],
     "branchPrefix": "renovate-",
     "branchPrefixOld": "renovate-",
     "dependencyDashboard": true,
+    "extends": [
+      "config:base"
+    ],    
     "ignorePaths": [],
     "ignoreUnstable": true,
     "packageRules": [

--- a/default.json
+++ b/default.json
@@ -5,8 +5,8 @@
     "branchPrefix": "renovate-",
     "branchPrefixOld": "renovate-",
     "dependencyDashboard": true,
-    "ignoreUnstable": true,
     "ignorePaths": [],
+    "ignoreUnstable": true,
     "packageRules": [
         {
             "matchManagers": ["dockerfile", "docker-compose", "github-actions", "kustomize"],

--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
     "branchPrefixOld": "renovate-",
     "dependencyDashboard": true,
     "ignoreUnstable": true,
+    "ignorePaths": [],
     "packageRules": [
         {
             "matchManagers": ["dockerfile", "docker-compose", "github-actions", "kustomize"],


### PR DESCRIPTION
Motivation
---
The preset `config:base` automatically ignores package manager files from **tests** files, we don't want to ignore packages in tests. Let's not ignore anything and then selectively ignore paths when needed

Modification
---
Don't ignore any paths

https://centeredge.atlassian.net/browse/PHNX-9098
