### PR TITLE
Ignore Linq2Couchbase >= 1.4.2 (PHNX-9282)

### DIFF
--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -7,6 +7,7 @@
             "matchUpdateTypes": ["patch", "minor"],
             "matchManagers": [ "nuget" ],
             "stabilityDays": 3
-        }
+        },
+        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" }        
     ]
 }


### PR DESCRIPTION
Motivation
---
Linq2Couchbase 1.4.2 has breaking changes that will cause problems if not handled carefully 


Modification
---
Ignore automatic updates to Linq2Couchbase on versions greater than than 1.4.2

https://centeredge.atlassian.net/browse/PHNX-9282
