### PR TITLE
Add configuration to allow updating private packages (PHNX-9425)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Renovate is a dependency update tool https://github.com/renovatebot/renovate
 ----
 
 - `rangeStrategy` is set to `bump` so minor/patch npm version updates would not be ignored
-- `stabilityDays` is helpful to prevent upgrading to packages that have only been released very recently. Such as npm packages are allowed to be removed from the npm repo within a few days of initial release. If we update a third party npm package and then it's removed from npm entirely that would not be good.
-
+- `stabilityDays` is helpful to prevent upgrading to packages that have only been released very recently. Such as npm packages are allowed to be removed from the npm repo within a few days of initial release. If we update a third party npm package and then it's removed from npm entirely that would not be good
+- When does Renovate update a repository?
+  - When the `schedule` is triggered
+  - When a renovate.json is changed
+  - When the checkbox "Check this box to trigger a request for Renovate to run again on this repository" is checked. This is in the Repisotories "Issues" tab --> Dependency Dashboard. However, the Issues tab isn't present in all repositories
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Renovate is a dependency update tool https://github.com/renovatebot/renovate
 - Presets documentation: https://docs.renovatebot.com/config-presets/
 - Run logs: https://app.renovatebot.com/dashboard#github/CenterEdge/
 - See any `renovate.json` in our repos for how to add a new Renovate configuration to a repo. Also repos with newly added renovate configs need to be added to github.com/settings/installations --> Integrations --> Applications --> Renovate Configure --> "Only Select Repositories"
+- In general, the default `renovate.json` for any repo that is added to Renovate to should look something like this:
+```json
+{
+  "extends": [
+    "github>CenterEdge/renovate-config//phoenix/default",
+    "github>CenterEdge/renovate-config//phoenix/nuget-minor",
+    "github>CenterEdge/renovate-config//phoenix/npm-minor",
+    "github>CenterEdge/renovate-config//phoenix/major"
+    "github>CenterEdge/renovate-config//phoenix/private-packages"
+  ],
+  "description": "The Renovate configuration presets are in https://github.com/CenterEdge/renovate-config"
+}
+```
 
 
 ----
@@ -15,7 +28,7 @@ Renovate is a dependency update tool https://github.com/renovatebot/renovate
 - When does Renovate update a repository?
   - When the `schedule` is triggered
   - When a renovate.json is changed
-  - When the checkbox "Check this box to trigger a request for Renovate to run again on this repository" is checked. This is in the Repisotories "Issues" tab --> Dependency Dashboard. However, the Issues tab isn't present in all repositories
+  - When the checkbox "Check this box to trigger a request for Renovate to run again on this repository" is checked. This is in the Repositories "Issues" tab --> Dependency Dashboard. However, the Issues tab isn't present in all repositories
 
 ----
 

--- a/phoenix/private-packages.json
+++ b/phoenix/private-packages.json
@@ -3,6 +3,8 @@
         "This preset is used to update private CenterEdge packages from our github package repository",
         "The tokens are generated from https://app.renovatebot.com/encrypt",
         "Include any packages in the matchPackageNames list to trigger Renovate to make pull requests for those packages",
+        "The `token` depends on an authorized github packages token, ghp, to be valid. If that github token expires then the",
+            "Renovate updates to private packages will break",
         "See https://docs.renovatebot.com/getting-started/private-packages/ for more information about private package configuration"
     ],
     "hostRules": [

--- a/phoenix/private-packages.json
+++ b/phoenix/private-packages.json
@@ -1,7 +1,7 @@
 {
     "description": [
         "This preset is used to update private CenterEdge packages from our github package repository",
-        "Include any packages in the matchPackageNames list to trigger Renovate to make pull requests for those packages",
+        "Include any packages in the packageRules.matchPackageNames list to trigger Renovate to make pull requests for those packages",
         "The tokens are generated from https://app.renovatebot.com/encrypt",
         "The tokens depend on an authorized github packages token, ghp, to be valid. If that github token expires then the",
             "Renovate updates to private packages will break",

--- a/phoenix/private-packages.json
+++ b/phoenix/private-packages.json
@@ -1,10 +1,11 @@
 {
     "description": [
         "This preset is used to update private CenterEdge packages from our github package repository",
-        "The tokens are generated from https://app.renovatebot.com/encrypt",
         "Include any packages in the matchPackageNames list to trigger Renovate to make pull requests for those packages",
-        "The `token` depends on an authorized github packages token, ghp, to be valid. If that github token expires then the",
+        "The tokens are generated from https://app.renovatebot.com/encrypt",
+        "The tokens depend on an authorized github packages token, ghp, to be valid. If that github token expires then the",
             "Renovate updates to private packages will break",
+            "See https://centeredge.atlassian.net/wiki/spaces/DO/pages/2969337857/GitHub+Packages+Setup for ghp setup",
         "See https://docs.renovatebot.com/getting-started/private-packages/ for more information about private package configuration"
     ],
     "hostRules": [

--- a/phoenix/private-packages.json
+++ b/phoenix/private-packages.json
@@ -1,0 +1,50 @@
+{
+    "description": [
+        "This preset is used to update private CenterEdge packages from our github package repository",
+        "The tokens are generated from https://app.renovatebot.com/encrypt",
+        "Include any packages in the matchPackageNames list to trigger Renovate to make pull requests for those packages",
+        "See https://docs.renovatebot.com/getting-started/private-packages/ for more information about private package configuration"
+    ],
+    "hostRules": [
+        {
+            "encrypted": {
+                "token": "wcFMA/xDdHCJBTolAQ/+JSp5hnVsfmqLWCzZMHAsVXvq6wkn2UH8PjzcLP1/zuWc42GjiLhHvIsJe1SODHca1BNgwMaj2u2gTGgKkGo2oDbt2/KQowUAHup1VeLxaIBc0mnrG5N3xZEFV4KC5fCSGO+8UwBB5J/odMIzBG9366P36XKlpvENSEM3R1YyXkkxi3a71vNQGn1IJFTNuKXhr0zZx0852QVGDILVXDwQewgI+maUtMwJ0zrC4JZE16TsOg3UOm5NmvpGtxwit0JEonAxiALj4vJ7hxMBQzd0KObLoafBD9vd8ptq+MVqISzaRSS1JKIn+BCmoRo9kmtZR5yG4DIaacth0Cd+odqukmrV8T0TcE8SSWmNbyFL/weJ8o1dp0xE24AstNWWaQvU407H/UikePfqoEFhazf/bdN7glG691ymXsnk2Xw4npwxH5Pfs37h5ErFJ7iI3MSJzm6ZnJvT8MoWOGpfxJxx+TjqDKM0wYMoytHdHNdkFbTEnqo+Lbpa8k9L6JAMog+SuJiFKbea+gdhJ6PRf0mbTF7S+jea0Bg5yv3oB0Fwj0S5Y/3r4kCqX8x3Os20FIh7YaJeMLpFLkvc8u6u0kueWTFf2pxNpHwCeX0fl0m4xBPAm0LI8LoFHBBNaD02IRy0GwRBMXt3QkBZY4g7TTGjH10BOdh26RBmCHHA48z8Cg/SeQGSDVI6fKXr8s/0jd4gOT80Loz7HLdf6C/aq4E35qsUjO89AoWdEG5iryqnSop5VO7XQAyb84V+jPAcLi0sZ0AbeNMYA4QMUnXJPU/DLtv2y5hM8t4/p0eGFD186YUMMrbknS6OETLqtEDUvPdKhCBLT050SQVemVI"
+            },
+            "hostType": "npm",
+            "matchHost": "https://npm.pkg.github.com/"
+        },
+        {
+            "encrypted": {
+                "token": "wcFMA/xDdHCJBTolAQ/+JSp5hnVsfmqLWCzZMHAsVXvq6wkn2UH8PjzcLP1/zuWc42GjiLhHvIsJe1SODHca1BNgwMaj2u2gTGgKkGo2oDbt2/KQowUAHup1VeLxaIBc0mnrG5N3xZEFV4KC5fCSGO+8UwBB5J/odMIzBG9366P36XKlpvENSEM3R1YyXkkxi3a71vNQGn1IJFTNuKXhr0zZx0852QVGDILVXDwQewgI+maUtMwJ0zrC4JZE16TsOg3UOm5NmvpGtxwit0JEonAxiALj4vJ7hxMBQzd0KObLoafBD9vd8ptq+MVqISzaRSS1JKIn+BCmoRo9kmtZR5yG4DIaacth0Cd+odqukmrV8T0TcE8SSWmNbyFL/weJ8o1dp0xE24AstNWWaQvU407H/UikePfqoEFhazf/bdN7glG691ymXsnk2Xw4npwxH5Pfs37h5ErFJ7iI3MSJzm6ZnJvT8MoWOGpfxJxx+TjqDKM0wYMoytHdHNdkFbTEnqo+Lbpa8k9L6JAMog+SuJiFKbea+gdhJ6PRf0mbTF7S+jea0Bg5yv3oB0Fwj0S5Y/3r4kCqX8x3Os20FIh7YaJeMLpFLkvc8u6u0kueWTFf2pxNpHwCeX0fl0m4xBPAm0LI8LoFHBBNaD02IRy0GwRBMXt3QkBZY4g7TTGjH10BOdh26RBmCHHA48z8Cg/SeQGSDVI6fKXr8s/0jd4gOT80Loz7HLdf6C/aq4E35qsUjO89AoWdEG5iryqnSop5VO7XQAyb84V+jPAcLi0sZ0AbeNMYA4QMUnXJPU/DLtv2y5hM8t4/p0eGFD186YUMMrbknS6OETLqtEDUvPdKhCBLT050SQVemVI"
+            },
+            "hostType": "nuget",
+            "matchHost": "https://nuget.pkg.github.com/CenterEdge/"
+        }
+    ],
+    "packageRules": [
+        {
+            "description": "The rules for private Nuget packages",
+            "major": {
+                "enabled": true
+            },
+            "matchPackageNames": [
+                "@centeredge/ng-camera-capture"
+            ],
+            "registryUrls": ["https://npm.pkg.github.com"]
+        },
+        {
+            "description": "The rules for private Nuget packages",
+            "major": {
+                "enabled": true
+            },
+            "matchPackageNames": [
+                "CenterEdge.Metrics.AspNetCore"
+            ],
+            "registryUrls": [
+                "https://nuget.pkg.github.com/CenterEdge/index.json",
+                "https://api.nuget.org/v3/index.json"
+            ]
+        }
+    ],
+    "npmrc": "@CenterEdge:registry=https://npm.pkg.github.com/"
+}


### PR DESCRIPTION
Motivation
----------
We would like to be able to use Renovate to help mass update our private packages across all repos

Modifications
-------------
- Add configuration to allow updating private packages
- Add more notes on random things

https://centeredge.atlassian.net/browse/PHNX-9425
