### PR TITLE
Don't upgrade CenterEdge.Metrics.AspNetCore to 2.3.0 (PHNX-9532)

### DIFF
--- a/phoenix/private-packages.json
+++ b/phoenix/private-packages.json
@@ -50,7 +50,8 @@
                 "https://nuget.pkg.github.com/CenterEdge/index.json",
                 "https://api.nuget.org/v3/index.json"
             ]
-        }
+        },
+        { "matchPackageNames": ["CenterEdge.Metrics.AspNetCore"], "allowedVersions": "<2.3.0" }
     ],
     "npmrc": "@CenterEdge:registry=https://npm.pkg.github.com/"
 }


### PR DESCRIPTION
Motivation
------------
Upgrading CenterEdge.Metrics.AspNetCore to 2.3.0 is causing build problems in several repositories and there doesn't seem to be an easy fix, so let's not automatically update it to keep other packages updates moving through successfully
```
Application startup exception: System.InvalidOperationException: Unable to resolve service for type 'CenterEdge.Metrics.ISpanMetricSink' while attempting to activate 'CenterEdge.Metrics.AspNetCore.CenterEdgeMetricMiddleware'.
```

Modifications
------------
Don't automatically upgrade CenterEdge.Metrics.AspNetCore to 2.3.0

https://centeredge.atlassian.net/browse/PHNX-9532
