### PR TITLE
Don't include private packages in the grouped PRs (PHNX-952)

### DIFF
--- a/phoenix/npm-minor.json
+++ b/phoenix/npm-minor.json
@@ -1,13 +1,33 @@
 {
-    "description": "This preset is used to combine update patch and minor package updates into one pull request",
+    "description": "This preset is used to combine third party patch and minor package updates into one pull request",
     "packageRules": [
         {
             "enabled": true,   
             "groupName": "npm Minor Packages (TODO JIRA)",
             "matchUpdateTypes": ["patch", "minor"],
             "matchManagers": [ "npm" ],
-            "stabilityDays": 3
-        }
+            "stabilityDays": 5,
+            "excludePackagePrefixes": ["Advantage", "advantage", "CECloud", "cecloud", "CenterEdge", "centeredge", "Phoenix", "phoenix" ],
+            "excludePackageNames": [
+                "authorization-typescript-node-client",
+                "camera-capture",
+                "ce-selenium-helpers",
+                "cecloud-mashtub-typescript-node-client",
+                "centeredge-mocker",
+                "client-common-services",
+                "corpsites-typescript-node-client",
+                "mashtub-angular11",
+                "mashtub-typescript-node-client",
+                "mashtub2-typescript-angular-client",
+                "mocks-microservices",
+                "ng-camera-capture",
+                "ng-client-common-services",
+                "openapi-generator-cli",
+                "pdf-typescript-node-client",
+                "syncstatus-typescript-node-client"
+            ]
+        },
+        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" }
     ],
     "rangeStrategy": "bump"
 }

--- a/phoenix/npm-minor.json
+++ b/phoenix/npm-minor.json
@@ -3,7 +3,7 @@
     "packageRules": [
         {
             "enabled": true,   
-            "groupName": "npm Minor Packages (TODO JIRA)",
+            "groupName": "npm Third Party Minor Packages (TODO JIRA)",
             "matchUpdateTypes": ["patch", "minor"],
             "matchManagers": [ "npm" ],
             "stabilityDays": 5,

--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -1,13 +1,15 @@
 {
-    "description": "This preset is used to combine update patch and minor package updates into one pull request",    
+    "description": "This preset is used to combine third party patch and minor package updates into one pull request",
     "packageRules": [
         {            
             "enabled": true,
             "groupName": "Nuget Minor Packages (TODO JIRA)",
             "matchUpdateTypes": ["patch", "minor"],
             "matchManagers": [ "nuget" ],
-            "stabilityDays": 3
+            "stabilityDays": 5,
+            "excludePackagePrefixes": ["Advantage", "advantage", "CECloud", "cecloud", "CenterEdge", "centeredge", "Phoenix", "phoenix" ],
+            "excludePackageNames": ["Yardarm.Sdk"]
         },
-        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" }        
+        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" }
     ]
 }

--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -3,7 +3,7 @@
     "packageRules": [
         {            
             "enabled": true,
-            "groupName": "Nuget Minor Packages (TODO JIRA)",
+            "groupName": "Nuget Third Party Minor Packages (TODO JIRA)",
             "matchUpdateTypes": ["patch", "minor"],
             "matchManagers": [ "nuget" ],
             "stabilityDays": 5,


### PR DESCRIPTION
Motivation
------------
Including our own private packages in the mass of bulk update PRs is asking for things to unexpectedly break and we should probably be more considerate of auto merging our own packages in the mix with other unrelated stuff

Modifications
------------
- Exclude our private packages in the grouped PRs, instead Renovate will create an individual PR for each private package
- Increase the days for the stability days check because that makes me feel better

https://centeredge.atlassian.net/browse/PHNX-952
