### PR TITLE
Ignore OpenTelemetry.xxx 1.0.0-rc9.10 (PHNX-9821)

### DIFF
--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -11,8 +11,8 @@
             "excludePackageNames": ["Yardarm.Sdk"]
         },
         { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },
+        { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": ">1.0.0-rc9.10" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": ">1.0.0-rc9.10" },
-        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": ">1.0.0-rc9.10" },
-        { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": ">1.0.0-rc9.10" }
+        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": ">1.0.0-rc9.10" }
     ]
 }

--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -10,6 +10,9 @@
             "excludePackagePrefixes": ["Advantage", "advantage", "CECloud", "cecloud", "CenterEdge", "centeredge", "Phoenix", "phoenix" ],
             "excludePackageNames": ["Yardarm.Sdk"]
         },
-        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" }
+        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },
+        { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": ">1.0.0-rc9.10" },
+        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": ">1.0.0-rc9.10" },
+        { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": ">1.0.0-rc9.10" }
     ]
 }


### PR DESCRIPTION
Motivation
---
OpenTelemetry packages with version 1.0.0-rc9.10 is causing problems try just waiting for the next packages releases to update this

Modification
---
Ignore OpenTelemetry.xxx 1.0.0-rc9.10

https://centeredge.atlassian.net/browse/PHNX-9821
