### PR TITLE
Set Max OpenTelemetry Version (PHNX-10007)

### DIFF
--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -11,8 +11,8 @@
             "excludePackageNames": ["Yardarm.Sdk"]
         },
         { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },
-        { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": ">1.0.0-rc9.10" },
-        { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": ">1.0.0-rc9.10" },
-        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": ">1.0.0-rc9.10" }
+        { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": "<=1.0.0-rc9.9" },
+        { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": "<=1.0.0-rc9.9" },
+        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" }
     ]
 }


### PR DESCRIPTION
Motivation
--------------

OpenTelemetry packages newer than 1.0.0-rc9.9 can cause deployments to fail.

Modifications
--------------

Set max allowed version to 1.0.0-rc9.9.

https://centeredge.atlassian.net/browse/PHNX-10007
