### PR TITLE
Ignore NEST versions greater than 7.8.1 (PHNX-10087)

### DIFF
--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -10,11 +10,11 @@
             "excludePackagePrefixes": ["Advantage", "advantage", "CECloud", "cecloud", "CenterEdge", "centeredge", "Phoenix", "phoenix" ],
             "excludePackageNames": ["Yardarm.Sdk"]
         },
-        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },
+        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },      
+        { "matchPackageNames": ["NEST"], "allowedVersions": "<=7.8.1" },
+        { "matchPackageNames": ["NEST.JsonNetSerializer"], "allowedVersions": "<=7.8.1" },
         { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": "<=1.0.0-rc9.9" },
-        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" },
-        { "matchPackageNames": ["NEST"], "allowedVersions": "<=7.8.1" },
-        { "matchPackageNames": ["NEST.JsonNetSerializer"], "allowedVersions": "<=7.8.1" }
+        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" }
     ]
 }

--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -13,6 +13,8 @@
         { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },
         { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": "<=1.0.0-rc9.9" },
-        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" }
+        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" },
+        { "matchPackageNames": ["NEST"], "allowedVersions": "<=7.8.1" },
+        { "matchPackageNames": ["NEST.JsonNetSerializer"], "allowedVersions": "<=7.8.1" }
     ]
 }


### PR DESCRIPTION
Motivation
---
NEST versions greater than 7.8.1 are causing errors in waivers service smoke tests "The client noticed that the server is not a supported distribution of Elasticsearch"

Modification
---
Ignore NEST versions greater than 7.8.1

https://centeredge.atlassian.net/browse/PHNX-10087
