### PR TITLE
Ignore OT.Exporter.Jaeger>1.3.2 (PHNX-10265)

### DIFF
--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -13,6 +13,7 @@
         { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },      
         { "matchPackageNames": ["NEST"], "allowedVersions": "<=7.8.1" },
         { "matchPackageNames": ["NEST.JsonNetSerializer"], "allowedVersions": "<=7.8.1" },
+        { "matchPackageNames": ["OpenTelemetry.Exporter.Jaeger"], "allowedVersions": "<=1.3.2" },
         { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" }


### PR DESCRIPTION
Motivation
---
Experienced a build fail for Open Telemetry package (Exporter.Jaeger" Version="1.4.0" />

Modification
---
Ignore this package for future updates

https://centeredge.atlassian.net/browse/PHNX-10265
