### PR TITLE
Ignore Swashbuckle CLI past 6.4.0(PHNX-10367)

### DIFF
--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -13,6 +13,7 @@
         { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },      
         { "matchPackageNames": ["NEST"], "allowedVersions": "<=7.8.1" },
         { "matchPackageNames": ["NEST.JsonNetSerializer"], "allowedVersions": "<=7.8.1" },
+        { "matchPackageNames": ["OpenTelemetry.Exporter.Jaeger"], "allowedVersions": "<=1.3.2" },
         { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" }

--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -16,6 +16,8 @@
         { "matchPackageNames": ["OpenTelemetry.Exporter.Jaeger"], "allowedVersions": "<=1.3.2" },
         { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": "<=1.0.0-rc9.9" },
-        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" }
+        { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" },
+        { "matchPackageNames": ["swashbuckle.aspnetcore.cli"], "allowedVersions": "<=6.4.0" }
+        
     ]
 }


### PR DESCRIPTION
Motivation 
---
Multiple PR's up for swashbuckle 6.5.0 update and they all fail to build

`Unhandled exception. System.IO.FileLoadException: Could not load file or assembly 'Swashbuckle.AspNetCore.Swagger, Version=6.5.0.0, Culture=neutral, PublicKeyToken=62657d7474907593'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)

File name: 'Swashbuckle.AspNetCore.Swagger, Version=6.5.0.0, Culture=neutral, PublicKeyToken=62657d7474907593'`

Modification
---
Ignore this update 

https://centeredge.atlassian.net/browse/PHNX-10367
