### PR TITLE
Add CECloud.Messenger to private packages whitelist (PHNX-10383)

### DIFF
--- a/phoenix/private-packages.json
+++ b/phoenix/private-packages.json
@@ -45,6 +45,7 @@
                 "enabled": true
             },
             "matchPackageNames": [
+                "CECloud.Messenger",
                 "CenterEdge.Metrics.AspNetCore",
                 "Phoenix.Microservice.Advantage"
             ],


### PR DESCRIPTION
Motivation
---
CECloud.Messenger has an update to stop logging "Requesting messages from queue..." all the time

Modifications
---
Add CECloud.Messenger to private packages whitelist

https://centeredge.atlassian.net/browse/PHNX-10383
