### PR TITLE
Only allow @types/lodash less than 4.14.194 (PHNX-12420)

### DIFF
--- a/phoenix/npm-minor.json
+++ b/phoenix/npm-minor.json
@@ -27,7 +27,8 @@
                 "syncstatus-typescript-node-client"
             ]
         },
-        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" }
+        { "matchPackageNames": ["Linq2Couchbase"], "allowedVersions": "<=1.4.1" },
+        { "matchPackageNames": ["@types/lodash"], "allowedVersions": "<4.14.194" }
     ],
     "rangeStrategy": "bump"
 }


### PR DESCRIPTION
Motivation
---
When @types/lodash was upgraded to 4.14.194 errors in our CI tests started showing similar to this:

```
node_modules/@types/lodash/common/object.d.ts(1025,21): error TS1110: Type expected.
node_modules/@types/lodash/common/object.d.ts(1026,24): error TS1005: ':' expected.
node_modules/@types/lodash/common/object.d.ts(1026,38): error TS1005: ';' expected.
node_modules/@types/lodash/common/object.d.ts(1027,26): error TS1005: ':' expected.
```

Modification
---
Only allow @types/lodash less than 4.14.194

https://centeredge.atlassian.net/browse/PHNX-12420
