### PR TITLE
Update the renovate schedule (PHNX-12686)

### DIFF
--- a/phoenix/default.json
+++ b/phoenix/default.json
@@ -32,7 +32,7 @@
         "- If any single packages aren't passing the [stabilityDays](https://docs.renovatebot.com/configuration-options/#stabilitydays) check then the entire PR containing other packages will not be made (ideally just that one package would be excluded, but this is a limitation of the current system). Search \"stability\" in the [Renovate logs](https://app.renovatebot.com/dashboard#github/CenterEdge/TempPackageManagerConcept) to find which package is being blocked",
         "- Our Renovate configurations are in https://github.com/CenterEdge/renovate-config"
     ],
-    "schedule": ["on Monday"],
+    "schedule": ["before 4am on Monday"],
     "suppressNotifications": ["artifactErrors"],
     "timezone": "America/New_York"
 }


### PR DESCRIPTION
Motivation
---
Github and renovate are fighting over the PR title and doing this:

example https://github.com/CenterEdge/CECloud.Webstores/pull/3530

![image](https://github.com/CenterEdge/renovate-config/assets/29711376/89fb6d5a-a29a-47ce-ad14-6bdfd236b5e6)

But why does renovate keep updating stuff? I thought we made it only run on Monday

Modification
---
Try using an exact schedule example included in the Renovate docs https://docs.renovatebot.com/presets-schedule/

https://centeredge.atlassian.net/browse/PHNX-12686
