### PR TITLE
Exclude OpenTelemetry.OTProtocol Versions Newer than 1.3.2  (PHNX-13147)

### DIFF
--- a/phoenix/nuget-minor.json
+++ b/phoenix/nuget-minor.json
@@ -14,6 +14,7 @@
         { "matchPackageNames": ["NEST"], "allowedVersions": "<=7.8.1" },
         { "matchPackageNames": ["NEST.JsonNetSerializer"], "allowedVersions": "<=7.8.1" },
         { "matchPackageNames": ["OpenTelemetry.Exporter.Jaeger"], "allowedVersions": "<=1.3.2" },
+        { "matchPackageNames": ["OpenTelemetry.Exporter.OpenTelemetryProtocol"], "allowedVersions": "<=1.3.2" },
         { "matchPackageNames": ["OpenTelemetry.Extensions.Hosting"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.AspNetCore"], "allowedVersions": "<=1.0.0-rc9.9" },
         { "matchPackageNames": ["OpenTelemetry.Instrumentation.Http"], "allowedVersions": "<=1.0.0-rc9.9" },


### PR DESCRIPTION
Motivation
---
We have had deployment issues with this package that sneaks by automated testing, we want to avoid this by excluding it from renovate PRS 

Modification
---
- Exclude package from new PRS made by renovate 

https://centeredge.atlassian.net/browse/PHNX-13147
