### PR TITLE
Enable github-actions (PHNX-13224)

### DIFF
--- a/phoenix/default.json
+++ b/phoenix/default.json
@@ -13,14 +13,14 @@
         "github>CenterEdge/renovate-config//phoenix/npm-minor",
         "github>CenterEdge/renovate-config//phoenix/nuget-minor",
         "github>CenterEdge/renovate-config//phoenix/private-packages"
-    ],    
+    ],
     "ignorePaths": [],
     "ignoreUnstable": true,
     "packageRules": [
         {
-            "matchManagers": ["dockerfile", "docker-compose", "github-actions", "kustomize"],
-            "enabled": false      
-        }         
+            "matchManagers": ["dockerfile", "docker-compose", "kustomize"],
+            "enabled": false
+        }
     ],
     "prBodyNotes": [
         "@CenterEdge engineers:",

--- a/phoenix/github-actions.json
+++ b/phoenix/github-actions.json
@@ -4,7 +4,6 @@
         {
             "enabled": true,
             "groupName": "Github Actions Updates",
-            "matchUpdateTypes": ["major", "minor", "patch"],
             "matchManagers": [ "github-actions" ],
             "stabilityDays": 5
         }

--- a/phoenix/github-actions.json
+++ b/phoenix/github-actions.json
@@ -1,0 +1,12 @@
+{
+    "description": "This preset is used to combine github-actions updates into one pull request",
+    "packageRules": [
+        {
+            "enabled": true,
+            "groupName": "Github Actions Updates",
+            "matchUpdateTypes": ["major", "minor", "patch"],
+            "matchManagers": [ "github-actions" ],
+            "stabilityDays": 5
+        }
+    ]
+}


### PR DESCRIPTION
# Motivations
Now that we're starting to use GitHub actions pretty heavily, we want package update prs to include anything for github-actions, including our own CenterEdge github actions

# Modifications
- Remove github-actions from the ignore list

https://centeredge.atlassian.net/browse/PHNX-13224
