### PR TITLE
Extend github-actions.json (PHNX-13231)

### DIFF
--- a/phoenix/default.json
+++ b/phoenix/default.json
@@ -9,6 +9,7 @@
     ],
     "extends": [
         "config:base",
+        "github>CenterEdge/renovate-config//phoenix/github-actions",
         "github>CenterEdge/renovate-config//phoenix/major",
         "github>CenterEdge/renovate-config//phoenix/npm-minor",
         "github>CenterEdge/renovate-config//phoenix/nuget-minor",

--- a/phoenix/github-actions.json
+++ b/phoenix/github-actions.json
@@ -3,7 +3,7 @@
     "packageRules": [
         {
             "enabled": true,
-            "groupName": "Github Actions Updates",
+            "groupName": "Github Actions",
             "matchManagers": [ "github-actions" ],
             "stabilityDays": 5
         }


### PR DESCRIPTION
# Motivations
GitHub actions renovate updates

# Modifications
- Adjust the group name, 'Updates' is already added to the group name as a prefix in PR's, no reason to have it in the group name
- Reference the github-actions.json in the default config

https://centeredge.atlassian.net/browse/PHNX-13231
