### PR TITLE
Group all GHA updates into one PR (PHNX-13316)

### DIFF
--- a/phoenix/github-actions.json
+++ b/phoenix/github-actions.json
@@ -4,6 +4,7 @@
         {
             "enabled": true,
             "groupName": "Github Actions",
+            "matchUpdateTypes": ["major", "minor", "patch"]
             "matchManagers": [ "github-actions" ],
             "stabilityDays": 5
         }


### PR DESCRIPTION
# Motivations
We don't really need different PR's if it's a minor/major/patch update

# Modifications
- Add ""matchUpdateTypes": ["major", "minor", "patch"]" to the github-actions config, in hopes it groups all the updates into one PR