### PR TITLE
Exclude CenterEdge actions updates from min stability days (PHNX-14030)

### DIFF
--- a/phoenix/github-actions.json
+++ b/phoenix/github-actions.json
@@ -9,6 +9,11 @@
             "separateMajorMinor": "false",
             "separateMinorPatch": "false",
             "stabilityDays": 5
+        },
+        {
+            "matchPackagePrefixes": ["centeredge/cd-actions", "centeredge/ci-actions"],
+            "matchManagers": [ "github-actions" ],
+            "stabilityDays": 0
         }
     ]
 }


### PR DESCRIPTION
# Motivations
Renovate prevents updates for a GitHub Actions package if it's not considered "stable" for 5 days, for external actions this is nice, but for internal actions, we don't really need it

# Modifications
- Exclude internal GitHub Actions packages from the min stability days renovate requirement

https://centeredge.atlassian.net/browse/PHNX-14030
